### PR TITLE
Fix metatable and improve performance

### DIFF
--- a/graphingwiki/plugin/macro/MetaRevisions.py
+++ b/graphingwiki/plugin/macro/MetaRevisions.py
@@ -46,5 +46,5 @@ def execute(macro, args):
 
     pagelist, metakeys = get_revisions(request, page)
 
-    return "".join(construct_table(request, pagelist,
+    return "".join(construct_table(request, dict(), pagelist,
                                    metakeys, 'Meta by Revision'))

--- a/graphingwiki/plugin/macro/MetaRevisions.py
+++ b/graphingwiki/plugin/macro/MetaRevisions.py
@@ -31,14 +31,13 @@
 from MoinMoin.Page import Page
 
 from graphingwiki.editing import get_revisions
-
 from MetaTable import construct_table
 
 Dependencies = ['metadata']
 
+
 def execute(macro, args):
     request = macro.request
-    _ = macro.request.getText
 
     if args:
         page = Page(request, args)
@@ -46,6 +45,6 @@ def execute(macro, args):
         page = request.page
 
     pagelist, metakeys = get_revisions(request, page)
-    
-    return "".join(construct_table(macro.request, pagelist, 
+
+    return "".join(construct_table(request, pagelist,
                                    metakeys, 'Meta by Revision'))

--- a/graphingwiki/plugin/macro/MetaTable.py
+++ b/graphingwiki/plugin/macro/MetaTable.py
@@ -218,7 +218,6 @@ def construct_table(request, pagelist, metakeys, legend='',
         pagepathstrip = int(pagepathstrip)
     except ValueError:
         pagepathstrip = 0
-        pass
     if pagepathstrip < 0:
         pagepathstrip = 0
 
@@ -253,7 +252,6 @@ def construct_table(request, pagelist, metakeys, legend='',
         limit = int(limit)
     except ValueError:
         limit = 0
-        pass
     if limit > maxpages or limit < 0:
         limit = 0
     if limit:

--- a/graphingwiki/plugin/macro/MetaTable.py
+++ b/graphingwiki/plugin/macro/MetaTable.py
@@ -79,12 +79,8 @@ COLORS = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine',
           'whitesmoke', 'yellow', 'yellowgreen']
 
 
-def wrap_span(request, cache, pageobj, key, data, id):
-    format_cache = cache.setdefault("format_wikitext", dict())
-
-    if data not in format_cache:
-        format_cache[data] = format_wikitext(request, data)
-    fdata = format_cache.get(data)
+def wrap_span(request, pageobj, key, data, id):
+    fdata = format_wikitext(request, data)
 
     if not key:
         return fdata
@@ -186,7 +182,7 @@ def t_cell(request, cache, pageobj, vals, head=0,
             if cellstyle == 'list':
                 out.append(formatter.listitem(1))
 
-            out.append(wrap_span(request, cache, pageobj, key, data,
+            out.append(wrap_span(request, pageobj, key, data,
                                  i))
 
             if cellstyle == 'list':
@@ -195,7 +191,7 @@ def t_cell(request, cache, pageobj, vals, head=0,
         first_val = False
 
     if not vals:
-        out.append(wrap_span(request, cache, pageobj, key, '', 0))
+        out.append(wrap_span(request, pageobj, key, '', 0))
 
     if cellstyle == 'list':
         out.append(formatter.bullet_list(1))

--- a/graphingwiki/plugin/macro/MetaTable.py
+++ b/graphingwiki/plugin/macro/MetaTable.py
@@ -104,11 +104,9 @@ def wrap_span(request, pageobj, key, data, id, parser=None):
         if key in linkdata:
             for pname in linkdata[key]:
                 if not data:
-                    pagename = pname
                     key = key.split('->')[-1]
                     break
                 if data in linkdata[key][pname] or header:
-                    pagename = pname
                     key = key.split('->')[-1]
                     break
 
@@ -123,7 +121,7 @@ def wrap_span(request, pageobj, key, data, id, parser=None):
 
 
 def t_cell(request, pageobj, vals, head=0,
-           style=None, rev='', key='', 
+           style=None, rev='', key='',
            pathstrip=0, linkoverride='', parser=None):
     formatter = request.formatter
     out = list()
@@ -159,7 +157,7 @@ def t_cell(request, pageobj, vals, head=0,
                                                rel='nofollow'))
                 img = request.theme.make_icon('formedit')
                 out.append(pageobj.link_to_raw(request, img,
-                                               querystr={'action': 
+                                               querystr={'action':
                                                          'MetaFormEdit'},
                                                rel='nofollow'))
                 out.append(formatter.span(0))
@@ -175,7 +173,7 @@ def t_cell(request, pageobj, vals, head=0,
                     pathstrip = len(dataparts) - 1
                 if pathstrip:
                     linktext = '/'.join(reversed(
-                            dataparts[:-pathstrip-1:-1]))
+                        dataparts[:-pathstrip - 1:-1]))
             out.append(formatter.pagelink(1, data, **kw))
             out.append(formatter.text(linktext))
             out.append(formatter.pagelink(0))
@@ -183,7 +181,7 @@ def t_cell(request, pageobj, vals, head=0,
             if cellstyle == 'list':
                 out.append(formatter.listitem(1))
 
-            out.append(wrap_span(request, pageobj, key, data, 
+            out.append(wrap_span(request, pageobj, key, data,
                                  i, parser=parser))
 
             if cellstyle == 'list':
@@ -203,7 +201,7 @@ def t_cell(request, pageobj, vals, head=0,
 
 
 def construct_table(request, pagelist, metakeys, legend='',
-                    checkAccess=True, styles=dict(), 
+                    checkAccess=True, styles=dict(),
                     options=dict(), parser=None):
     request.page.formatter = request.formatter
     formatter = request.formatter
@@ -224,7 +222,7 @@ def construct_table(request, pagelist, metakeys, legend='',
     if pagepathstrip < 0:
         pagepathstrip = 0
 
-    ## Properties
+    # Properties
     # Default and override properties
     propdefault = options.get('propdefault', '')
     propoverride = options.get('propoverride', '')
@@ -282,7 +280,7 @@ def construct_table(request, pagelist, metakeys, legend='',
         if send_pages:
             # Upper left cell contains table size or has the desired legend
             if legend:
-                out.extend(t_cell(request, pagename, [legend], 
+                out.extend(t_cell(request, pagename, [legend],
                                   parser=parser))
             elif limit:
                 message = ["Showing (%s/%s) pages" %
@@ -300,7 +298,7 @@ def construct_table(request, pagelist, metakeys, legend='',
         style = styles.get(key, dict())
 
         if key == 'gwikipagename':
-            out.extend(t_cell(request, pageobj, [pageobj.page_name], 
+            out.extend(t_cell(request, pageobj, [pageobj.page_name],
                               head=1, style=style, parser=parser))
             return out
 
@@ -329,7 +327,7 @@ def construct_table(request, pagelist, metakeys, legend='',
         if colormatch:
             style['bgcolor'] = colormatch
 
-        out.extend(t_cell(request, pageobj, metas[key], 
+        out.extend(t_cell(request, pageobj, metas[key],
                           style=style, key=key, parser=parser))
 
         if colormatch:
@@ -366,7 +364,7 @@ def construct_table(request, pagelist, metakeys, legend='',
             linktext = ''
             if pagelinkonly:
                 linktext = _('[link]')
-            out.extend(t_cell(request, pageobj, [pageobj.page_name], 
+            out.extend(t_cell(request, pageobj, [pageobj.page_name],
                               head=1, rev=revision, pathstrip=pagepathstrip,
                               linkoverride=linktext, parser=parser))
 
@@ -463,7 +461,7 @@ def construct_table(request, pagelist, metakeys, legend='',
             request.page = pageobj
             request.formatter.page = pageobj
 
-            out.extend(page_cell(request, pageobj, revision, row, 
+            out.extend(page_cell(request, pageobj, revision, row,
                                  send_pages, pagelinkonly, pagepathstrip))
 
             for key in metakeys:
@@ -483,7 +481,6 @@ def do_macro(request, args, **kw):
     formatter = request.formatter
     _ = request.getText
     out = list()
-    pagename = request.page.page_name
 
     # Note, metatable_parseargs deals with permissions
     pagelist, metakeys, styles = metatable_parseargs(request, args,

--- a/graphingwiki/plugin/macro/MetaTable.py
+++ b/graphingwiki/plugin/macro/MetaTable.py
@@ -168,7 +168,7 @@ def t_cell(request, cache, pageobj, vals, head=0,
                 out.append(formatter.span(0))
             kw = dict()
             if rev:
-                kw['querystr'] = '?action=recall&amp;rev=' + rev
+                kw['querystr'] = 'action=recall&rev=' + rev
             linktext = data
             if linkoverride:
                 linktext = linkoverride

--- a/graphingwiki/plugin/macro/MetaTable.py
+++ b/graphingwiki/plugin/macro/MetaTable.py
@@ -31,7 +31,6 @@ import re
 from urllib import quote
 
 from MoinMoin.Page import Page
-from MoinMoin.parser.text_moin_wiki import Parser
 
 from graphingwiki import url_escape
 from graphingwiki.editing import metatable_parseargs, get_metas, \
@@ -80,8 +79,8 @@ COLORS = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine',
           'whitesmoke', 'yellow', 'yellowgreen']
 
 
-def wrap_span(request, pageobj, key, data, id, parser=None):
-    fdata = format_wikitext(request, data, parser)
+def wrap_span(request, pageobj, key, data, id):
+    fdata = format_wikitext(request, data)
 
     if not key:
         return fdata
@@ -122,7 +121,7 @@ def wrap_span(request, pageobj, key, data, id, parser=None):
 
 def t_cell(request, pageobj, vals, head=0,
            style=None, rev='', key='',
-           pathstrip=0, linkoverride='', parser=None):
+           pathstrip=0, linkoverride=''):
     formatter = request.formatter
     out = list()
 
@@ -182,7 +181,7 @@ def t_cell(request, pageobj, vals, head=0,
                 out.append(formatter.listitem(1))
 
             out.append(wrap_span(request, pageobj, key, data,
-                                 i, parser=parser))
+                                 i))
 
             if cellstyle == 'list':
                 out.append(formatter.listitem(0))
@@ -190,8 +189,7 @@ def t_cell(request, pageobj, vals, head=0,
         first_val = False
 
     if not vals:
-        out.append(wrap_span(request, pageobj, key, '', 0,
-                             parser=parser))
+        out.append(wrap_span(request, pageobj, key, '', 0))
 
     if cellstyle == 'list':
         out.append(formatter.bullet_list(1))
@@ -202,7 +200,7 @@ def t_cell(request, pageobj, vals, head=0,
 
 def construct_table(request, pagelist, metakeys, legend='',
                     checkAccess=True, styles=dict(),
-                    options=dict(), parser=None):
+                    options=dict()):
     request.page.formatter = request.formatter
     formatter = request.formatter
     _ = request.getText
@@ -278,17 +276,14 @@ def construct_table(request, pagelist, metakeys, legend='',
         if send_pages:
             # Upper left cell contains table size or has the desired legend
             if legend:
-                out.extend(t_cell(request, pagename, [legend],
-                                  parser=parser))
+                out.extend(t_cell(request, pagename, [legend]))
             elif limit:
                 message = ["Showing (%s/%s) pages" %
                            (len(pagelist), maxpages)]
 
-                out.extend(t_cell(request, pagename, message,
-                                  parser=parser))
+                out.extend(t_cell(request, pagename, message))
             else:
-                out.extend(t_cell(request, pagename, [legend],
-                                  parser=parser))
+                out.extend(t_cell(request, pagename, [legend]))
 
     def key_cell(request, metas, key, pageobj,
                  styles, properties):
@@ -297,7 +292,7 @@ def construct_table(request, pagelist, metakeys, legend='',
 
         if key == 'gwikipagename':
             out.extend(t_cell(request, pageobj, [pageobj.page_name],
-                              head=1, style=style, parser=parser))
+                              head=1, style=style))
             return out
 
         colors = [x.strip() for x in properties
@@ -326,7 +321,7 @@ def construct_table(request, pagelist, metakeys, legend='',
             style['bgcolor'] = colormatch
 
         out.extend(t_cell(request, pageobj, metas[key],
-                          style=style, key=key, parser=parser))
+                          style=style, key=key))
 
         if colormatch:
             del style['bgcolor']
@@ -364,7 +359,7 @@ def construct_table(request, pagelist, metakeys, legend='',
                 linktext = _('[link]')
             out.extend(t_cell(request, pageobj, [pageobj.page_name],
                               head=1, rev=revision, pathstrip=pagepathstrip,
-                              linkoverride=linktext, parser=parser))
+                              linkoverride=linktext))
 
         return out
 
@@ -399,12 +394,10 @@ def construct_table(request, pagelist, metakeys, legend='',
 
             if name:
                 out.extend(t_cell(request, request.page, [name],
-                                  style=headerstyle, key=key,
-                                  parser=parser))
+                                  style=headerstyle, key=key))
             else:
                 out.extend(t_cell(request, request.page, [key],
-                                  style=headerstyle, key=key,
-                                  parser=parser))
+                                  style=headerstyle, key=key))
 
     if metakeys:
         out.append(formatter.table_row(0))
@@ -427,12 +420,10 @@ def construct_table(request, pagelist, metakeys, legend='',
 
             if name:
                 out.extend(t_cell(request, tmp_page, [name],
-                                  style=headerstyle, key=key,
-                                  parser=parser))
+                                  style=headerstyle, key=key))
             else:
                 out.extend(t_cell(request, tmp_page, [key],
-                                  style=headerstyle, key=key,
-                                  parser=parser))
+                                  style=headerstyle, key=key))
 
             row = row + 1
 
@@ -496,15 +487,13 @@ def do_macro(request, args, **kw):
         out.append(formatter.table(0) + u'</div>')
         return "".join(out)
 
-    parser = Parser('', request)
-
     options = dict({'args': args}.items() + kw.items())
     divfmt = {'class': "metatable", 'data-options': quote(json.dumps(options))}
     out.append(formatter.div(1, **divfmt))
     # We're sure the user has the access to the page, so don't check
     out.extend(construct_table(request, pagelist, metakeys,
                                checkAccess=False, styles=styles,
-                               options=options, parser=parser))
+                               options=options))
 
     def action_link(action, linktext, args):
         req_url = request.script_root + "/" + \


### PR DESCRIPTION
Commit f142b5b introduced reusing of Page and Parser objects to gain some speed. However it turned out that Parser reuse is not safe, as it has some state and thus single malformed meta value can break whole table.

Example of broken behaviour:

PageA:

```
 note:: {{{
This is broken, as multiline meta values are not really supported.
}}}

----
CategoryNote
```

PageB:

```
 note:: Normal value.

----
CategoryNote
```

PageMetatable:

```
<<MetaTable(CategoryNote)>>
```

Broken value on PageA causes Parser to enter in code block parsing mode and as parser is reused that mode is used also when trying to render value from PageB.

The fix is to reverts that change. Based on my tests it either doesn't affect on performance at all or reduces it by less than 10%. However as this is one of the most wildly used parts of GraphingWiki, I decided to do some further optimizations to counter that drop in performance.

Commit dfd14b5 adds caching of results from calls to format_wikitext() and theme.make_icon() inside single construct_table() call. That improves performance roughly 30% with my test data set.
