### PR TITLE
Add finish() to script request objects

### DIFF
--- a/graphingwiki/__init__.py
+++ b/graphingwiki/__init__.py
@@ -42,10 +42,13 @@ def RequestCLI(pagename='', parse=True):
             script.parser.set_defaults(page=pagename)
         script.options, script.args = script.parser.parse_args()
         script.init_request()
+        script.request.finish = lambda: graphdata_close(script.request)
         return script.request
 
     # Default values
-    return ScriptContext(None, pagename)
+    context = ScriptContext(None, pagename)
+    context.finish = lambda: graphdata_close(context)
+    return context
 
 # Get action name for forms
 def actionname(request, pagename=None):

--- a/scripts/gwiki-editpage
+++ b/scripts/gwiki-editpage
@@ -4,7 +4,6 @@
 import sys, os
 
 from optparse import OptionParser
-from graphingwiki import graphdata_close
 from graphingwiki.editing import savetext
 
 from MoinMoin.Page import Page
@@ -57,4 +56,4 @@ if __name__ == '__main__':
         savetext(req, pagename, mytext)
 
     # Must finish the request to ensure that metadata is saved
-    graphdata_close(req)
+    req.finish()

--- a/scripts/gwiki-rehash
+++ b/scripts/gwiki-rehash
@@ -167,5 +167,3 @@ for pageobj in pages:
 
 # Must finish the scriptcontext to ensure that metadata is saved & committed
 scriptcontext.finish()
-scriptcontext.graphdata.commit()
-scriptcontext.graphdata.close()


### PR DESCRIPTION
Call request.finish() to commit metadata and release locks to graphdata
database.
