### PR TITLE
invite: Always try SMTP AUTH if configured and supported by server

### DIFF
--- a/graphingwiki/invite.py
+++ b/graphingwiki/invite.py
@@ -285,9 +285,8 @@ def send_message(request, message, recipient_filter=lambda x: True):
                 smtp.login(*request.cfg.mail_login.split(" ", 1))
 
             smtp.sendmail(sender, recipients, message.as_string())
-            for recipient in recipients:
-                logging.info("%s invited %s to wiki %s" %
-                             (sender, recipients, request.cfg.interwikiname))
+            logging.info("Invite mail for wiki %s sent from %s to %s" %
+                         (request.cfg.interwikiname, sender, ", ".join(recipients)))
         except Exception, exc:
             raise InviteException("Could not send the mail: %r" % exc)
     finally:

--- a/graphingwiki/invite.py
+++ b/graphingwiki/invite.py
@@ -277,24 +277,17 @@ def send_message(request, message, recipient_filter=lambda x: True):
             smtp.connect(request.cfg.mail_smarthost)
             smtp.ehlo()
 
-            try:
+            if smtp.has_extn('starttls'):
                 smtp.starttls()
-            except smtplib.SMTPException:
-                pass
-            else:
                 smtp.ehlo()
 
-            try:
-                smtp.sendmail(sender, recipients, message.as_string())
-                for recipient in recipients:
-                    logging.info("%s invited %s to wiki %s" %
-                                 (sender, recipients,
-                                  request.cfg.interwikiname))
-            except (smtplib.SMTPSenderRefused, smtplib.SMTPRecipientsRefused), error:
-                if not getattr(request.cfg, "mail_login", None):
-                    raise error
+            if smtp.has_extn('auth') and getattr(request.cfg, "mail_login", None):
                 smtp.login(*request.cfg.mail_login.split(" ", 1))
-                smtp.sendmail(sender, recipients, message.as_string())
+
+            smtp.sendmail(sender, recipients, message.as_string())
+            for recipient in recipients:
+                logging.info("%s invited %s to wiki %s" %
+                             (sender, recipients, request.cfg.interwikiname))
         except Exception, exc:
             raise InviteException("Could not send the mail: %r" % exc)
     finally:


### PR DESCRIPTION
Some mail servers will close the connection immediately if trying to send unauthenticated.